### PR TITLE
[IDP-2068] Automerge official dependency from microsoft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test with the dotnet CLI
         run: dotnet test tests 
         env:
-          GH_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.TEST_GITHUB_MG}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test with the dotnet CLI
         run: dotnet test tests 
         env:
-          TEST_GITHUB_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}
+          GH_GITHUB_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test with the dotnet CLI
         run: dotnet test tests 
         env:
-          GH_GITHUB_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}
+          TEST_GITHUB_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test with the dotnet CLI
         run: dotnet test tests 
         env:
-          TEST_GITHUB_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true    
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains the shared renovate configurations.
 
 The shared configurations are baselines. Each project is free to set their own rules on top of this configuration.
 
-# Usage
+## Usage
 
-## GitHub projects
+### GitHub projects
 
 ````json
 {
@@ -17,7 +17,17 @@ The shared configurations are baselines. Each project is free to set their own r
 }
 ````
 
-## Azure DevOps
+#### Enabling Auto-Merge Functionality for GitHub
+
+Auto-merge has been set up using the [branch approach](https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging), chosen to minimize noise and allow for the bypassing of PR review requirements.
+
+For those utilizing branch protection rules on the default branch, specific adjustments are necessary to facilitate auto-merge capabilities for GitHub:
+
+1. **Update Branch Policies**: Modify your branch protection settings to permit the account or service running Renovate to bypass pull request review requirements.
+
+2. **Handling Status Checks**: If your repository enforces "Require status checks to pass before merging," be aware that Renovate will be unable to merge changes into the main branch if any of these checks fail. It will fallback to create a PR.
+
+### Azure DevOps
 
 ````json
 {
@@ -64,7 +74,3 @@ steps:
   parameters:
     githubToken: $(GITHUB_COM_TOKEN)
 ````
-
-## Support Auto Merge
-
-TODO: Explain ruleset required.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For those utilizing branch protection rules on the default branch, specific adju
 
 1. **Update Branch Policies**: Modify your branch protection settings to permit the account or service running Renovate to bypass pull request review requirements.
 
-2. **Handling Status Checks**: If your repository enforces "Require status checks to pass before merging," be aware that Renovate will be unable to merge changes into the main branch if any of these checks fail. It will fallback to create a PR.
+2. **Handling Status Checks**: If your repository enforces "Require status checks to pass before merging", be aware that Renovate will be unable to merge changes into the target branch if any of these checks fail. It will fallback to create a pull request.
 
 ### Azure DevOps
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The shared configurations are baselines. Each project is free to set their own r
 }
 ````
 
-# Azure DevOps
+## Azure DevOps
 
 ````json
 {
@@ -64,3 +64,7 @@ steps:
   parameters:
     githubToken: $(GITHUB_COM_TOKEN)
 ````
+
+## Support Auto Merge
+
+TODO: Explain ruleset required.

--- a/default.json
+++ b/default.json
@@ -43,7 +43,7 @@
   ],
   "packageRules": [
     {
-      "description": "Automatically merge PRs for Microsoft minor and patch updates",
+      "description": "Automatically merge minor and patch updates for Microsoft dependencies",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -43,6 +43,20 @@
   ],
   "packageRules": [
     {
+      "description": "Automatically merge PRs for Microsoft minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "matchPackageNames": [
+        "dotnet-sdk",
+        "mcr.microsoft.com/dotnet/sdk",
+        "mcr.microsoft.com/dotnet/aspnet",
+        "mcr.microsoft.com/dotnet/runtime",
+        "mcr.microsoft.com/dotnet/runtime-deps",
+        "/^[mM]icrosoft\\./",
+        "/^[sS]ystem\\./"
+      ]
+    },
+    {
       "groupName": "gitversion-msbuild",
       "description": "Disable major updates as their are breaking changes. The documentation is not complete, so it would require time to figure out the new configuration",
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -46,6 +46,7 @@
       "description": "Automatically merge minor and patch updates for Microsoft dependencies",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
+      "automergeType": "branch",
       "matchPackageNames": [
         "dotnet-sdk",
         "mcr.microsoft.com/dotnet/sdk",

--- a/tests/GitInfos.cs
+++ b/tests/GitInfos.cs
@@ -3,3 +3,6 @@ namespace renovate_config.tests;
 internal sealed record PullRequestInfos(string Title, IEnumerable<string> Labels, IEnumerable<PackageUpdateInfos> PackageUpdatesInfos, bool isAutoMergeEnabled);
 
 internal sealed record PackageUpdateInfos(string Package, string Type, string Update);
+
+internal sealed record CommitInfo(string Message);
+

--- a/tests/PullrequestsInfos.cs
+++ b/tests/PullrequestsInfos.cs
@@ -1,5 +1,5 @@
 namespace renovate_config.tests;
 
-internal sealed record PullRequestInfos(string Title, IEnumerable<string> Labels, IEnumerable<PackageUpdateInfos> PackageUpdatesInfos);
+internal sealed record PullRequestInfos(string Title, IEnumerable<string> Labels, IEnumerable<PackageUpdateInfos> PackageUpdatesInfos, bool isAutoMergeEnabled);
 
 internal sealed record PackageUpdateInfos(string Package, string Type, string Update);

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -167,17 +167,6 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: System.Text.Json
                   Type: nuget
                   Update: major
-            - Title: chore(deps): update microsoft
-              Labels:
-                - renovate
-              PackageUpdatesInfos:
-                - Package: microsoft.AspNetCore.Authentication.OpenIdConnect
-                  Type: nuget
-                  Update: patch
-                - Package: Microsoft.Azure.AppConfiguration.AspNetCore
-                  Type: nuget
-                  Update: minor
-              isAutoMergeEnabled: true
             - Title: chore(deps): update microsoft (major)
               Labels:
                 - renovate
@@ -191,7 +180,6 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
             """);
     }
     
-    // Maybe not required
     [Fact]
     public async Task Given_Microsoft_Minor_Dependencies_When_CI_Succeed_Then_Automatically_Push_On_Main()
     {
@@ -217,23 +205,17 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
         await testContext.RunRenovate();
         
         // Need to run renovate a second time so that branch is merged
-        await Task.Delay(10);
+        // Need to pull commit status to see is check is completed
+        await testContext.WaitForLatestCommitChecksToSucceed();
         await testContext.RunRenovate();
 
-        // TODO: Validate that it is merged on main
-        // await testContext.AssertPullRequests(
-        //     """
-        //     - Title: chore(deps): update dependency system.text.json  to redacted[security]
-        //       Labels:
-        //         - security
-        //       PackageUpdatesInfos:
-        //         - Package: System.Text.Json
-        //           Type: nuget
-        //           Update: patch
-        //       isAutoMergeEnabled: true
-        //     """);
+        await testContext.AssertCommits("""
+            - Message: chore(deps): update dependency system.text.json  to redacted[security]
+            - Message: IDP ScaffoldIt automated test
+            """);
     }
     
+    // Will fail locally since it use the developer user which have push permission on main
     [Fact]
     public async Task Given_Microsoft_Minor_Dependencies_When_CI_Fail_Then_Create_PR()
     {

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -33,6 +33,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: mcr.microsoft.com/dotnet/sdk
                   Type: stage
                   Update: patch
+              isAutoMergeEnabled: true
             - Title: chore(deps): update dotnet-sdk  to redacted(major)
               Labels:
                 - renovate
@@ -172,6 +173,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: Microsoft.Azure.AppConfiguration.AspNetCore
                   Type: nuget
                   Update: minor
+              isAutoMergeEnabled: true
             - Title: chore(deps): update microsoft (major)
               Labels:
                 - renovate
@@ -182,6 +184,43 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: microsoft.AspNetCore.Authentication.OpenIdConnect
                   Type: nuget
                   Update: major
+            """);
+    }
+    
+    // Maybe not required
+    [Fact]
+    public async Task RenovateMicrosoftAutomergeDependencies()
+    {
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+
+        testContext.AddCiFile();
+        
+        testContext.AddFile("CODEOWNERS",
+          """
+          * @gsoft-inc/internal-developer-platform
+          """);
+        
+        testContext.AddFile("project.csproj",
+          """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <ItemGroup>
+            <PackageReference Include="System.Text.Json" Version="8.0.0" />
+          </ItemGroup>
+        </Project>
+        """);
+
+        await testContext.RunRenovate();
+
+        await testContext.AssertPullRequests(
+            """
+            - Title: chore(deps): update dependency system.text.json  to redacted[security]
+              Labels:
+                - security
+              PackageUpdatesInfos:
+                - Package: System.Text.Json
+                  Type: nuget
+                  Update: patch
+              isAutoMergeEnabled: true
             """);
     }
 

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -178,7 +178,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
     }
     
     [Fact]
-    public async Task Given_Microsoft_Minor_Dependencies_Update_When_CI_Succeed_Then_Automerge_By_Pushing_On_Main()
+    public async Task Given_Microsoft_Minor_Dependencies_Update_When_CI_Succeed_Then_AutoMerge_By_Pushing_On_Main()
     {
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
@@ -213,7 +213,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
     }
     
     [Fact]
-    public async Task Given_Microsoft_Minor_Dependencies_Update_When_CI_Fail_Then_Abort_Automerge_And_Fallback_To_Create_PR()
+    public async Task Given_Microsoft_Minor_Dependencies_Update_When_CI_Fail_Then_Abort_AutoMerge_And_Fallback_To_Create_PR()
     {
       await using var testContext = await TestContext.CreateAsync(testOutputHelper);
     

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -18,23 +18,15 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
+        
+        // Need to pull commit status to see is check is completed
+        await testContext.WaitForLatestCommitChecksToSucceed();
+        
+        // Need to run renovate a second time so that branch is merged
+        await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
             """
-            - Title: chore(deps): update dotnet-sdk
-              Labels:
-                - renovate
-              PackageUpdatesInfos:
-                - Package: dotnet-sdk
-                  Type: dotnet-sdk
-                  Update: patch
-                - Package: mcr.microsoft.com/dotnet/aspnet
-                  Type: final
-                  Update: patch
-                - Package: mcr.microsoft.com/dotnet/sdk
-                  Type: stage
-                  Update: patch
-              isAutoMergeEnabled: true
             - Title: chore(deps): update dotnet-sdk  to redacted(major)
               Labels:
                 - renovate
@@ -48,6 +40,11 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: mcr.microsoft.com/dotnet/sdk
                   Type: stage
                   Update: major
+            """);
+        
+        await testContext.AssertCommits("""
+            - Message: chore(deps): update dependency system.text.json  to redacted[security]
+            - Message: IDP ScaffoldIt automated test
             """);
     }
 

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -43,7 +43,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
             """);
         
         await testContext.AssertCommits("""
-            - Message: chore(deps): update dependency system.text.json  to redacted[security]
+            - Message: chore(deps): update dotnet-sdk
             - Message: IDP ScaffoldIt automated test
             """);
     }
@@ -154,6 +154,11 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
+        
+        // Need to run renovate a second time so that branch is merged
+        // Need to pull commit status to see is check is completed
+        await testContext.WaitForLatestCommitChecksToSucceed();
+        await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
             """
@@ -174,6 +179,11 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 - Package: microsoft.AspNetCore.Authentication.OpenIdConnect
                   Type: nuget
                   Update: major
+            """);
+        
+        await testContext.AssertCommits("""
+            - Message: chore(deps): update microsoft
+            - Message: IDP ScaffoldIt automated test
             """);
     }
     

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -292,14 +292,8 @@ internal sealed class TestContext(
 
     private static async Task<string> GetGitHubToken(ITestOutputHelper outputHelper)
     {
-        var token = Environment.GetEnvironmentVariable("TEST_GITHUB_TOKEN");
-
-        if (string.IsNullOrEmpty(token))
-        {
-            // gh auth Login with token using echo
-            var (stdout, stdError) = await ExecuteCommand(outputHelper, "echo", [$"{token}", "|", "gh", "auth", "login", "--with-token"]);
-        }
-
+        var token = Environment.GetEnvironmentVariable("GH_TOKEN");
+        
         if (string.IsNullOrEmpty(token))
         {
             var (stdout, _) = await ExecuteCommand(outputHelper, "gh", ["auth", "token"]);

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -219,7 +219,7 @@ internal sealed class TestContext(
 
         foreach (var branch in branches)
         {
-            if (!string.Equals(branch.Name, DefaultBranchName))
+            if (branch.Name != DefaultBranchName)
             {
                 await WaitForCommitAssociatedWorkflowsToSucceed(branch.Commit!.Sha!);
             }

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -34,6 +34,8 @@ internal sealed class TestContext(
     public static async Task<TestContext> CreateAsync(ITestOutputHelper outputHelper)
     {
         var gitHubClient = await GetGitHubClient(outputHelper);
+        
+        await ExecuteCommand(outputHelper, "gh", ["auth", "status"]);
 
         var temporaryDirectory = TemporaryDirectory.Create();
         var repoPath = temporaryDirectory.FullPath;

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -240,7 +240,7 @@ internal sealed class TestContext(
     
     private async Task<CheckResults> GetCommitChecks(string commitSha)
     {
-        var (stdOut, stdError) = await ExecuteCommand( outputHelper,
+        var (stdOut, stdError) = await ExecuteCommand(outputHelper,
             "gh", new[]
             {
                 "api",
@@ -292,7 +292,13 @@ internal sealed class TestContext(
 
     private static async Task<string> GetGitHubToken(ITestOutputHelper outputHelper)
     {
-        var token = Environment.GetEnvironmentVariable("GH_GITHUB_TOKEN");
+        var token = Environment.GetEnvironmentVariable("TEST_GITHUB_TOKEN");
+
+        if (string.IsNullOrEmpty(token))
+        {
+            // gh auth Login with token using echo
+            var (stdout, stdError) = await ExecuteCommand(outputHelper, "echo", [$"{token}", "|", "gh", "auth", "login", "--with-token"]);
+        }
 
         if (string.IsNullOrEmpty(token))
         {
@@ -308,7 +314,7 @@ internal sealed class TestContext(
 
         return token;
     }
-
+    
     private static async Task<GitHubClient> GetGitHubClient(ITestOutputHelper outputHelper)
     {
         if (_sharedGitHubClient != null)

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -292,7 +292,7 @@ internal sealed class TestContext(
 
     private static async Task<string> GetGitHubToken(ITestOutputHelper outputHelper)
     {
-        var token = Environment.GetEnvironmentVariable("TEST_GITHUB_TOKEN");
+        var token = Environment.GetEnvironmentVariable("GH_GITHUB_TOKEN");
 
         if (string.IsNullOrEmpty(token))
         {

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -170,7 +170,7 @@ internal sealed class TestContext(
         {
             MarkdownDocument markdownDocument = Markdown.Parse(pullRequest.Body!, pipeline);
             var prTitle = pullRequest.Title;
-            var prLabels = pullRequest.Labels!.Select(x => x.Name).Order();
+            var prLabels = pullRequest.Labels?.Select(x => x.Name).Order();
 
             var table = markdownDocument.OfType<Table>().First();
             var rows = table.Skip(1).OfType<TableRow>().ToArray();

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -270,7 +270,6 @@ internal sealed class TestContext(
     private static async Task<string> GetGitHubToken(ITestOutputHelper outputHelper)
     {
         var token = Environment.GetEnvironmentVariable("GH_TOKEN");
-        
         if (string.IsNullOrEmpty(token))
         {
             var (stdout, _) = await ExecuteCommand(outputHelper, "gh", ["auth", "token"]);

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -158,7 +158,7 @@ internal sealed class TestContext(
         // ReSharper restore ExplicitCallerInfoArgument
     }
 
-    public async Task<IEnumerable<PullRequestInfos>>  GetPullRequests()
+    public async Task<IEnumerable<PullRequestInfos>> GetPullRequests()
     {
         var pullRequests = await gitHubClient.Repos[RepositoryOwner][RepositoryName].Pulls.GetAsync() ?? [];
 

--- a/tests/renovate-config.tests.csproj
+++ b/tests/renovate-config.tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="3.0.7" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="1.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/renovate-config.tests.csproj
+++ b/tests/renovate-config.tests.csproj
@@ -12,12 +12,12 @@
 
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.6.6" />
+    <PackageReference Include="GitHub.Octokit.SDK" Version="0.0.26" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Meziantou.Framework.FullPath" Version="1.0.13" />
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="3.0.7" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="1.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Add automerge rule for official Microsoft dependency.

**Notes**

We need to use the [Branch ](https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging) approach to avoid the Pull Request approval limitation.  This means we need to allow the renovate bot to push on main without approval. We should still have a branch policy that every push on main must have a successful CI.