### PR TITLE
[IDP-2241] Do not ignore modules, tests and examples directories

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,6 +20,9 @@
     ":rebaseStalePrs",
     ":semanticCommits"
   ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,


### PR DESCRIPTION
See internal issue description.

`ignorePresets` is helpful when extending a preset, as explained here: https://docs.renovatebot.com/configuration-options/#ignorepresets

We don't version node_modules, bower_components (this is so 2010) so it should not impact consumers
![image](https://github.com/user-attachments/assets/1b5953b2-281d-441a-a727-025a02f4002d)
