### PR TITLE
[IDP-2269] Wait 3 days of release age unless it's Workleap dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,9 +50,9 @@
       "groupName": "Allow Workleap's NuGet and NPM packages to be updated immediately",
       "minimumReleaseAge": "0 days",
       "matchPackageNames": [
-        "/^[wW]orkleap\\./",
-        "/^[oO]ffice[vV]ibe\\./",
-        "/^[sS]share[gG]ate\\./",
+        "/^Workleap\\./i",
+        "/^Officevibe\\./i",
+        "/^Sharegate\\./i",
         "/^@workleap",
         "/^@sharegate",
         "/^@officevibe",
@@ -73,11 +73,12 @@
         "mcr.microsoft.com/dotnet/runtime",
         "mcr.microsoft.com/dotnet/runtime-deps",
         "Azure.Identity",
-        "/^[mM]icrosoft\\./",
-        "/^[sS]ystem\\./",
+        "/^Microsoft\\./i",
+        "/^System\\./i",
         "coverlet.collector",
         "xunit",
-        "/^xunit\\./"
+        "/^xunit\\./i",
+        "/^MongoDB\\./i"
       ]
     },
     {
@@ -107,8 +108,8 @@
     {
       "groupName": "microsoft",
       "matchPackageNames": [
-        "/^[mM]icrosoft\\./",
-        "/^[sS]ystem\\./"
+        "/^Microsoft\\./i",
+        "/^System\\./i"
       ],
       "extends": [
         ":separateMajorReleases"
@@ -118,7 +119,13 @@
       "groupName": "hangfire monorepo",
       "description": "Group Hangfire dependencies to make sure the build succeeds since they have strict version restrictions",
       "matchManagers": ["nuget"],
-      "matchPackageNames": ["/^[hH]angfire(\\.|$)/"]
+      "matchPackageNames": ["/^Hangfire(\\.|$)/i"]
+    },
+    {
+      "groupName": "mongodb monorepo",
+      "description": "Group MongoDB dependencies update in a single PR to avoid conflicts",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^MongoDB\\./i"]
     },
     {
       "groupName": "pipeline dependencies",

--- a/default.json
+++ b/default.json
@@ -72,10 +72,10 @@
         "mcr.microsoft.com/dotnet/aspnet",
         "mcr.microsoft.com/dotnet/runtime",
         "mcr.microsoft.com/dotnet/runtime-deps",
-        "/^Azure\\.Identity/i",
+        "/^Azure\\.Identity$/i",
         "/^Microsoft\\./i",
         "/^System\\./i",
-        "/^coverlet\\.collector/i",
+        "/^coverlet\\.collector$/i",
         "/^xunit(\\.|$)/i",
         "/^MongoDB\\./i"
       ]
@@ -84,7 +84,7 @@
       "groupName": "gitversion-msbuild",
       "description": "Disable major updates as their are breaking changes. The documentation is not complete, so it would require time to figure out the new configuration",
       "matchPackageNames": [
-        "/^GitVersion\\.MsBuild/i"
+        "/^GitVersion\\.MsBuild$/i"
       ],
       "extends": [
         ":disableMajorUpdates"

--- a/default.json
+++ b/default.json
@@ -47,7 +47,7 @@
   ],
   "packageRules": [
     {
-      "groupName": "Allow Workleap's NuGet and NPM packages to be updated immediately",
+      "description": "Allow Workleap's NuGet and NPM packages to be updated immediately",
       "minimumReleaseAge": "0 days",
       "matchPackageNames": [
         "/^Workleap\\./i",

--- a/default.json
+++ b/default.json
@@ -29,6 +29,7 @@
   "dependencyDashboard": false,
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "configMigration": true,
+  "minimumReleaseAge": "3 days",
   "customManagers": [
     {
       "customType": "regex",
@@ -46,7 +47,22 @@
   ],
   "packageRules": [
     {
-      "description": "Automatically merge minor and patch updates for Microsoft dependencies",
+      "groupName": "Allow Workleap's NuGet and NPM packages to be updated immediately",
+      "minimumReleaseAge": "0 days",
+      "matchPackageNames": [
+        "/^[wW]orkleap\\./",
+        "/^[oO]ffice[vV]ibe\\./",
+        "/^[sS]share[gG]ate\\./",
+        "/^@workleap",
+        "/^@sharegate",
+        "/^@officevibe",
+        "/^@hopper-ui/",
+        "/^@orbit-ui/",
+        "/^@squide/"
+      ]
+    },
+    {
+      "description": "Automatically merge minor and patch updates for Microsoft and trusted, well-known dependencies",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "branch",
@@ -56,8 +72,12 @@
         "mcr.microsoft.com/dotnet/aspnet",
         "mcr.microsoft.com/dotnet/runtime",
         "mcr.microsoft.com/dotnet/runtime-deps",
+        "Azure.Identity",
         "/^[mM]icrosoft\\./",
-        "/^[sS]ystem\\./"
+        "/^[sS]ystem\\./",
+        "coverlet.collector",
+        "xunit",
+        "/^xunit\\./"
       ]
     },
     {
@@ -80,7 +100,6 @@
         "mcr.microsoft.com/dotnet/runtime",
         "mcr.microsoft.com/dotnet/runtime-deps"
       ],
-      "minimumReleaseAge": "3 days",
       "extends": [
         ":separateMajorReleases"
       ]

--- a/default.json
+++ b/default.json
@@ -72,10 +72,10 @@
         "mcr.microsoft.com/dotnet/aspnet",
         "mcr.microsoft.com/dotnet/runtime",
         "mcr.microsoft.com/dotnet/runtime-deps",
-        "Azure.Identity",
+        "/^Azure\\.Identity/i",
         "/^Microsoft\\./i",
         "/^System\\./i",
-        "coverlet.collector",
+        "/^coverlet\\.collector/i",
         "/^xunit(\\.|$)/i",
         "/^MongoDB\\./i"
       ]
@@ -84,7 +84,7 @@
       "groupName": "gitversion-msbuild",
       "description": "Disable major updates as their are breaking changes. The documentation is not complete, so it would require time to figure out the new configuration",
       "matchPackageNames": [
-        "GitVersion.MsBuild"
+        "/^GitVersion\\.MsBuild/i"
       ],
       "extends": [
         ":disableMajorUpdates"

--- a/default.json
+++ b/default.json
@@ -76,8 +76,7 @@
         "/^Microsoft\\./i",
         "/^System\\./i",
         "coverlet.collector",
-        "xunit",
-        "/^xunit\\./i",
+        "/^xunit(\\.|$)/i",
         "/^MongoDB\\./i"
       ]
     },

--- a/tests/GitInfos.cs
+++ b/tests/GitInfos.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace renovate_config.tests;
 
-internal sealed record PullRequestInfos(string Title, IEnumerable<string> Labels, IEnumerable<PackageUpdateInfos> PackageUpdatesInfos, bool isAutoMergeEnabled);
+[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Keeping git DTOs together")]
+internal sealed record PullRequestInfos(string Title, IEnumerable<string> Labels, IEnumerable<PackageUpdateInfos> PackageUpdatesInfos, bool IsAutoMergeEnabled);
 
 internal sealed record PackageUpdateInfos(string Package, string Type, string Update);
 

--- a/tests/MarkdownExtensions.cs
+++ b/tests/MarkdownExtensions.cs
@@ -13,9 +13,10 @@ internal static class MarkdownExtensions
         renderer.Render(obj);
         return writer.ToString();
     }
+
     public static string InnerText(this MarkdownObject obj)
     {
         var inlines = obj.Descendants<LiteralInline>();
-        return string.Join(" ", inlines.Select(inline=> inline.ToNormalizedString()));
+        return string.Join(" ", inlines.Select(inline => inline.ToNormalizedString()));
     }
 }

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -58,12 +58,11 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
             /*lang=xml*/"""
             <Project Sdk="Microsoft.NET.Sdk">
               <ItemGroup>
-                <PackageReference Include="Hangfire" Version="1.7.0" />
-                <PackageReference Include="Hangfire.Core" Version="1.7.0" />
-                <PackageReference Include="Hangfire.NetCore" Version="1.7.0" />
-                <PackageReference Include="Hangfire.Pro" Version="2.3.2" />
-                <PackageReference Include="Hangfire.Pro.Redis" Version="2.3.2" />
-                <PackageReference Include="Hangfire.Throttling" Version="1.1.1" />
+                <PackageReference Include="Hangfire" Version="1.7.1" />
+                <PackageReference Include="Hangfire.AspNetCore" Version="1.7.1" />
+                <PackageReference Include="Hangfire.Core" Version="1.7.1" />
+                <PackageReference Include="Hangfire.NetCore" Version="1.7.1" />
+                <PackageReference Include="Hangfire.SqlServer" Version="1.7.1" />
               </ItemGroup>
             </Project>
             """);
@@ -73,17 +72,23 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         await testContext.AssertPullRequests(
             """
-            - Title: chore(deps): update hangfire monorepo
+            - Title: chore(deps): update hangfire monorepo to redacted
               Labels:
                 - renovate
               PackageUpdatesInfos:
                 - Package: Hangfire
                   Type: nuget
                   Update: minor
+                - Package: Hangfire.AspNetCore
+                  Type: nuget
+                  Update: minor
                 - Package: Hangfire.Core
                   Type: nuget
                   Update: minor
-                - Package: Hangfire.Pro.Redis
+                - Package: Hangfire.NetCore
+                  Type: nuget
+                  Update: minor
+                - Package: Hangfire.SqlServer
                   Type: nuget
                   Update: minor
             """);
@@ -101,34 +106,6 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                 <PackageReference Include="MongoDB.Bson" Version="2.27.0" />
                 <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
                 <PackageReference Include="MongoDB.Driver.Core" Version="2.27.0" />
-              </ItemGroup>
-            </Project>
-            """);
-
-        await testContext.PushFilesOnDefaultBranch();
-        await testContext.RunRenovate();
-
-        await testContext.AssertPullRequests(
-            "[]");
-    }
-
-    [Fact]
-    public async Task Given_MongoDB_Minor_Dependencies_Update_When_CI_Succeed_Then_AutoMerge_By_Pushing_On_Main()
-    {
-        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
-
-        testContext.AddCiFile();
-
-        testContext.AddFile("CODEOWNERS",
-            """
-            * @gsoft-inc/internal-developer-platform
-            """);
-
-        testContext.AddFile("project.csproj",
-            /*lang=xml*/"""
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="System.Text.Json" Version="8.0.0" />
               </ItemGroup>
             </Project>
             """);
@@ -309,10 +286,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         testContext.AddCiFile();
 
-        testContext.AddFile("CODEOWNERS",
-            """
-            * @gsoft-inc/internal-developer-platform
-            """);
+        testContext.AddInternalDeveloperPlatformCodeOwnersFile();
 
         testContext.AddFile("project.csproj",
             /*lang=xml*/"""
@@ -345,10 +319,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         testContext.AddFaillingCiFile();
 
-        testContext.AddFile("CODEOWNERS",
-            """
-            * @gsoft-inc/internal-developer-platform
-            """);
+        testContext.AddInternalDeveloperPlatformCodeOwnersFile();
 
         testContext.AddFile("project.csproj",
             /*lang=xml*/"""

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -19,15 +19,15 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
-        
+
         await testContext.WaitForLatestCommitChecksToSucceed();
-        
+
         // Need to run renovate a second time so that branch get merged
         await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
             """
-            - Title: chore(deps): update dotnet-sdk  to redacted(major)
+            - Title: chore(deps): update dotnet-sdk to redacted(major)
               Labels:
                 - renovate
               PackageUpdatesInfos:
@@ -41,8 +41,9 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
                   Type: stage
                   Update: major
             """);
-        
-        await testContext.AssertCommits("""
+
+        await testContext.AssertCommits(
+            """
             - Message: chore(deps): update dotnet-sdk
             - Message: IDP ScaffoldIt automated test
             """);
@@ -54,24 +55,24 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
         testContext.AddFile("project.csproj",
-          """
-        <Project Sdk="Microsoft.NET.Sdk">
-          <ItemGroup>
-            <PackageReference Include="Hangfire" Version="1.7.0" />
-            <PackageReference Include="Hangfire.Core" Version="1.7.0" />
-            <PackageReference Include="Hangfire.NetCore" Version="1.7.0" />
-            <PackageReference Include="Hangfire.Pro" Version="2.3.2" />
-            <PackageReference Include="Hangfire.Pro.Redis" Version="2.3.2" />
-            <PackageReference Include="Hangfire.Throttling" Version="1.1.1" />
-          </ItemGroup>
-        </Project>
-        """);
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Hangfire" Version="1.7.0" />
+                <PackageReference Include="Hangfire.Core" Version="1.7.0" />
+                <PackageReference Include="Hangfire.NetCore" Version="1.7.0" />
+                <PackageReference Include="Hangfire.Pro" Version="2.3.2" />
+                <PackageReference Include="Hangfire.Pro.Redis" Version="2.3.2" />
+                <PackageReference Include="Hangfire.Throttling" Version="1.1.1" />
+              </ItemGroup>
+            </Project>
+            """);
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
-          """
+            """
             - Title: chore(deps): update hangfire monorepo
               Labels:
                 - renovate
@@ -94,34 +95,56 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
         testContext.AddFile("project.csproj",
-          /*lang=xml*/"""
-          <Project Sdk="Microsoft.NET.Sdk">
-            <ItemGroup>
-              <PackageReference Include="MongoDB.Bson" Version="2.28.0" />
-              <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-              <PackageReference Include="MongoDB.Driver.Core" Version="2.28.0" />
-            </ItemGroup>
-          </Project>
-          """);
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="MongoDB.Bson" Version="2.27.0" />
+                <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
+                <PackageReference Include="MongoDB.Driver.Core" Version="2.27.0" />
+              </ItemGroup>
+            </Project>
+            """);
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
-          """
-            - Title: chore(deps): update mongodb monorepo
-              Labels:
-                - renovate
-              PackageUpdatesInfos:
-                - Package: MongoDB.Bson
-                  Type: nuget
-                  Update: minor
-                - Package: MongoDB.Driver
-                  Type: nuget
-                  Update: minor
-                - Package: MongoDB.Driver.Core
-                  Type: nuget
-                  Update: minor
+            "[]");
+    }
+
+    [Fact]
+    public async Task Given_MongoDB_Minor_Dependencies_Update_When_CI_Succeed_Then_AutoMerge_By_Pushing_On_Main()
+    {
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+
+        testContext.AddCiFile();
+
+        testContext.AddFile("CODEOWNERS",
+            """
+            * @gsoft-inc/internal-developer-platform
+            """);
+
+        testContext.AddFile("project.csproj",
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="System.Text.Json" Version="8.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        await testContext.PushFilesOnDefaultBranch();
+        await testContext.RunRenovate();
+
+        // Need to run renovate a second time so that branch is merged
+        // Need to pull commit status to see is check is completed
+        await testContext.WaitForLatestCommitChecksToSucceed();
+        await testContext.RunRenovate();
+
+        await testContext.AssertCommits(
+            """
+            - Message: chore(deps): update dependency system.text.json to redacted[security]
+            - Message: IDP ScaffoldIt automated test
             """);
     }
 
@@ -131,70 +154,70 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
         testContext.AddFile("package.json",
-          """
-        {
-          "dependencies": {
-            "@azure/msal-browser": "^3.13.0",
-            "@azure/msal-react": "~2.0.15"
-          },
-          "devDependencies": {
-            "@storybook/addon-essentials": "^8.0.10",
-            "@storybook/addon-interactions": "~8.0.10"
-          }
-        }
-        """);
+            /*lang=json*/"""
+            {
+              "dependencies": {
+                "@azure/msal-browser": "^3.13.0",
+                "@azure/msal-react": "~2.0.15"
+              },
+              "devDependencies": {
+                "@storybook/addon-essentials": "^8.0.10",
+                "@storybook/addon-interactions": "~8.0.10"
+              }
+            }
+            """);
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
             """
-        - Title: fix(deps): pin dependencies
-          Labels:
-            - renovate
-          PackageUpdatesInfos:
-            - Package: @azure/msal-browser
-              Type: dependencies
-              Update: pin
-            - Package: @azure/msal-react
-              Type: dependencies
-              Update: pin
-            - Package: @storybook/addon-essentials
-              Type: devDependencies
-              Update: pin
-            - Package: @storybook/addon-interactions
-              Type: devDependencies
-              Update: pin
-        """);
+            - Title: fix(deps): pin dependencies
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: @azure/msal-browser
+                  Type: dependencies
+                  Update: pin
+                - Package: @azure/msal-react
+                  Type: dependencies
+                  Update: pin
+                - Package: @storybook/addon-essentials
+                  Type: devDependencies
+                  Update: pin
+                - Package: @storybook/addon-interactions
+                  Type: devDependencies
+                  Update: pin
+            """);
     }
 
     [Fact]
     public async Task Given_Microsoft_Major_Dependencies_Updates_Then_Open_PR()
     {
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
-        
+
         testContext.AddFile("project.csproj",
-          """
-        <Project Sdk="Microsoft.NET.Sdk">
-          <ItemGroup>
-            <PackageReference Include="System.Text.Json" Version="7.0.0" />
-            <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="1.0.2" />
-            <PackageReference Include="microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.0" />
-            <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
-            <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
-              <PrivateAssets>all</PrivateAssets>
-              <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            </PackageReference>
-          </ItemGroup>
-        </Project>
-        """);
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="System.Text.Json" Version="7.0.0" />
+                <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="1.0.2" />
+                <PackageReference Include="microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.0" />
+                <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+                  <PrivateAssets>all</PrivateAssets>
+                  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+              </ItemGroup>
+            </Project>
+            """);
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
 
         await testContext.AssertPullRequests(
             """
-            - Title: chore(deps): update dependency system.text.json  to redacted[security]
+            - Title: chore(deps): update dependency system.text.json to redacted[security]
               Labels:
                 - security
               PackageUpdatesInfos:
@@ -215,58 +238,68 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task Given_Microsoft_And_Workleap_Dependencies_Updates_Then_Open_Multiple_PRs()
+    public async Task Given_Various_Dependencies_Updates_Then_Open_Multiple_PRs_And_AutoMerge_Microsoft_Only()
     {
-      await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
-      testContext.AddFile("project.csproj",
-        /*lang=xml*/"""
-        <Project Sdk="Microsoft.NET.Sdk">
-          <ItemGroup>
-            <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-            <PackageReference Include="MongoDB.Bson" Version="2.28.0" />
-            <PackageReference Include="Workleap.Extensions.Configuration.Substitution" Version="1.1.2" />
-          </ItemGroup>
-        </Project>
-        """);
+        testContext.AddFile("project.csproj",
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Hangfire.NetCore" Version="1.7.1" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+                <PackageReference Include="Workleap.Extensions.Configuration.Substitution" Version="1.1.2" />
+              </ItemGroup>
+            </Project>
+            """);
 
-      testContext.AddFile("package.json",
-        /*lang=json*/"""
-        {
-          "dependencies": {
-            "@squide/core": "5.2.0"
-          }
-        }
-        """);
+        testContext.AddFile("package.json",
+            /*lang=json*/"""
+            {
+              "dependencies": {
+                "@squide/core": "5.2.0"
+              }
+            }
+            """);
 
-      await testContext.PushFilesOnDefaultBranch();
-      await testContext.RunRenovate();
+        await testContext.PushFilesOnDefaultBranch();
+        await testContext.RunRenovate();
 
-      await testContext.AssertPullRequests(
-        """
-          - Title: chore(deps): update dependency system.text.json  to redacted[security]
-            Labels:
-              - security
-            PackageUpdatesInfos:
-              - Package: System.Text.Json
-                Type: nuget
-                Update: major
-          - Title: chore(deps): update microsoft (major)
-            Labels:
-              - renovate
-            PackageUpdatesInfos:
-              - Package: Microsoft.ApplicationInsights.AspNetCore
-                Type: nuget
-                Update: major
-              - Package: microsoft.AspNetCore.Authentication.OpenIdConnect
-                Type: nuget
-                Update: major
-          - Title: chore(deps): update workleap (major)
-            Labels:
-              - renovate
-            PackageUpdatesInfos:
-              -
-        """);
+        await testContext.AssertPullRequests(
+            """
+            - Title: chore(deps): update dependency hangfire.netcore to redacted
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Hangfire.NetCore
+                  Type: nuget
+                  Update: minor
+            - Title: chore(deps): update dependency workleap.extensions.configuration.substitution to redacted
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Workleap.Extensions.Configuration.Substitution
+                  Type: nuget
+                  Update: patch
+            - Title: fix(deps): update dependency @squide/core to redacted
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: @squide/core
+                  Type: dependencies
+                  Update: minor
+            """);
+
+        // Need to run renovate a second time so that branch is merged
+        // Need to pull commit status to see is check is completed
+        await testContext.WaitForLatestCommitChecksToSucceed();
+        await testContext.RunRenovate();
+
+        await testContext.AssertCommits(
+            """
+            - Message: chore(deps): update dependency system.text.json to redacted[security]
+            - Message: IDP ScaffoldIt automated test
+            """);
     }
 
     [Fact]
@@ -275,76 +308,76 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
         testContext.AddCiFile();
-        
+
         testContext.AddFile("CODEOWNERS",
-          """
-          * @gsoft-inc/internal-developer-platform
-          """);
-        
+            """
+            * @gsoft-inc/internal-developer-platform
+            """);
+
         testContext.AddFile("project.csproj",
-          """
-        <Project Sdk="Microsoft.NET.Sdk">
-          <ItemGroup>
-            <PackageReference Include="System.Text.Json" Version="8.0.0" />
-          </ItemGroup>
-        </Project>
-        """);
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="System.Text.Json" Version="8.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
 
         await testContext.PushFilesOnDefaultBranch();
         await testContext.RunRenovate();
-        
+
         // Need to run renovate a second time so that branch is merged
         // Need to pull commit status to see is check is completed
         await testContext.WaitForLatestCommitChecksToSucceed();
         await testContext.RunRenovate();
 
-        await testContext.AssertCommits("""
-            - Message: chore(deps): update dependency system.text.json  to redacted[security]
+        await testContext.AssertCommits(
+            """
+            - Message: chore(deps): update dependency system.text.json to redacted[security]
             - Message: IDP ScaffoldIt automated test
             """);
     }
-    
+
     [Fact]
     public async Task Given_Microsoft_Minor_Dependencies_Update_When_CI_Fail_Then_Abort_AutoMerge_And_Fallback_To_Create_PR()
     {
-      await using var testContext = await TestContext.CreateAsync(testOutputHelper);
-    
-      testContext.AddFaillingCiFile();
-        
-      testContext.AddFile("CODEOWNERS",
-        """
-        * @gsoft-inc/internal-developer-platform
-        """);
-        
-      testContext.AddFile("project.csproj",
-        """
-        <Project Sdk="Microsoft.NET.Sdk">
-          <ItemGroup>
-            <PackageReference Include="System.Text.Json" Version="8.0.0" />
-          </ItemGroup>
-        </Project>
-        """);
-    
-      await testContext.PushFilesOnDefaultBranch();
-      
-      
-      await testContext.RunRenovate();
-      await testContext.WaitForLatestCommitChecksToSucceed();
-      
-      // Need to run renovate a second time to create PR on CI failures
-      await testContext.RunRenovate();
-    
-      await testContext.AssertPullRequests(
-          """
-          - Title: chore(deps): update dependency system.text.json  to redacted[security]
-            Labels:
-              - security
-            PackageUpdatesInfos:
-              - Package: System.Text.Json
-                Type: nuget
-                Update: patch
-            isAutoMergeEnabled: true
-          """);
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+
+        testContext.AddFaillingCiFile();
+
+        testContext.AddFile("CODEOWNERS",
+            """
+            * @gsoft-inc/internal-developer-platform
+            """);
+
+        testContext.AddFile("project.csproj",
+            /*lang=xml*/"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="System.Text.Json" Version="8.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        await testContext.PushFilesOnDefaultBranch();
+
+        await testContext.RunRenovate();
+        await testContext.WaitForLatestCommitChecksToSucceed();
+
+        // Need to run renovate a second time to create PR on CI failures
+        await testContext.RunRenovate();
+
+        await testContext.AssertPullRequests(
+            """
+            - Title: chore(deps): update dependency system.text.json to redacted[security]
+              Labels:
+                - security
+              PackageUpdatesInfos:
+                - Package: System.Text.Json
+                  Type: nuget
+                  Update: patch
+              IsAutoMergeEnabled: true
+            """);
     }
 
     [Fact]
@@ -353,7 +386,7 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);
 
         testContext.AddFile("project.csproj",
-            """
+            /*lang=xml*/"""
             <Project Sdk="Microsoft.NET.Sdk">
               <ItemGroup>
                 <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" />

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -50,6 +50,14 @@ internal sealed class TestContext(
         temporaryDirectory.CreateTextFile(path, content);
     }
 
+    public void AddInternalDeveloperPlatformCodeOwnersFile()
+    {
+        temporaryDirectory.CreateTextFile("CODEOWNERS",
+            """
+            * @gsoft-inc/internal-developer-platform
+            """);
+    }
+
     public void AddCiFile()
     {
         temporaryDirectory.CreateTextFile(".github/workflows/ci.yml",

--- a/tests/TestContext.cs
+++ b/tests/TestContext.cs
@@ -58,7 +58,7 @@ internal sealed class TestContext(
             """);
     }
 
-    public void AddCiFile()
+    public void AddSuccessfulWorkflowFileToSatisfyBranchPolicy()
     {
         temporaryDirectory.CreateTextFile(".github/workflows/ci.yml",
             /*lang=yaml*/"""
@@ -75,13 +75,13 @@ internal sealed class TestContext(
                 build:
                     runs-on: ubuntu-latest
                     steps:
-                        - name: Sleep
+                        - name: Dummy successful step
                           run: sleep 1
             """
             );
     }
 
-    public void AddFaillingCiFile()
+    public void AddFailingWorklowFileToSatisfyBranchPolicy()
     {
         temporaryDirectory.CreateTextFile(".github/workflows/ci.yml",
             /*lang=yaml*/"""
@@ -98,7 +98,7 @@ internal sealed class TestContext(
                 build:
                     runs-on: ubuntu-latest
                     steps:
-                        - name: Fail step
+                        - name: Dummy failing step
                           run: exit 1
             """
         );
@@ -214,7 +214,7 @@ internal sealed class TestContext(
         return commitInfos;
     }
 
-    public async Task WaitForLatestCommitChecksToSucceed()
+    public async Task WaitForBranchPolicyChecksToSucceed()
     {
         var branches = await gitHubClient.Repos[RepositoryOwner][RepositoryName].Branches.GetAsync() ?? [];
 

--- a/tests/renovate-config.tests.csproj
+++ b/tests/renovate-config.tests.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="1.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Octokit" Version="13.0.1" />
+    <PackageReference Include="Workleap.DotNet.CodingStandards" Version="0.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
> [!IMPORTANT]  
> I ended up scope creeping this PR as there were a few referenced packages in the system tests that did not exist in nuget.org (ex: Hangfire.NetCore 1.7.0). Some other packages were private (Hangfire Pro). The code style was a mess. Method names weren't explanatory, so I fixed that too.

### Planned changes

- Wait 3 days of release age unless it's Workleap dependencies.
- Add system tests.

### Scope creep

- Auto-merge more Microsoft/well-known dependencies.
- Use case-insensitive regexes.
- Use coding standards.
- Improve tests and method names.
- Inject (more) language hints in raw string literals.