### PR TITLE
Update service-renovate-config.yaml to use proper link [IDP-2286]

### DIFF
--- a/.cortex/catalog/service-renovate-config.yaml
+++ b/.cortex/catalog/service-renovate-config.yaml
@@ -19,6 +19,6 @@ info:
     provider: CORTEX
   x-cortex-link:
   - type: cortex
-    url: https://github.com/gsoft-inc/cortex-gitops/blob/main/.cortex/catalog/service-renovate-config.yaml
+    url: https://github.com/gsoft-inc/renovate-config/blob/main/.cortex/catalog/service-renovate-config.yaml
     name: Edit current Cortex entity in GitHub
 


### PR DESCRIPTION
https://gsoftdev.atlassian.net/browse/IDP-2286

The Cortex edit link was pointing to the gitops one.