### PR TITLE
IDP-2393 - Enable auto-merge

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows]
+ - Version: [e.g. 1.2.3]
+ - IDE: [e.g. Rider]
+ - etc.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- Please fill out any relevant sections and remove those that don't apply -->
+
+## Description of changes
+<!-- What was changed in this pull request? -->
+
+## Breaking changes
+<!-- What breaking changes were added (if any) and how are they addressed? -->
+
+## Additional checks
+<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->
+
+- [ ] Updated the documentation of the project to reflect the changes
+- [ ] Added new tests that cover the code changes

--- a/all-automerge.json
+++ b/all-automerge.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>gsoft-inc/renovate-config",
+    ":automergeBranch",
+    ":automergeMinor"
+  ]
+}

--- a/default.json
+++ b/default.json
@@ -18,8 +18,7 @@
   "extends": [
     "config:recommended",
     ":rebaseStalePrs",
-    ":semanticCommits",
-    ":separateMajorReleases"
+    ":semanticCommits"
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,

--- a/default.json
+++ b/default.json
@@ -79,6 +79,15 @@
       ]
     },
     {
+      "groupName": "workleap",
+      "matchPackageNames": [
+        "/^[wW]orkleap\\./"
+      ],
+      "extends": [
+        ":separateMajorReleases"
+      ]
+    },
+    {
       "groupName": "hangfire monorepo",
       "description": "Group Hangfire dependencies to make sure the build succeeds since they have strict version restrictions",
       "matchManagers": ["nuget"],

--- a/default.json
+++ b/default.json
@@ -18,7 +18,8 @@
   "extends": [
     "config:recommended",
     ":rebaseStalePrs",
-    ":semanticCommits"
+    ":semanticCommits",
+    ":separateMajorReleases"
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,

--- a/microsoft-automerge.json
+++ b/microsoft-automerge.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+      "github>gsoft-inc/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "groupName": "microsoft",
+      "matchPackageNames": [
+        "/^[mM]icrosoft\\./",
+        "/^[sS]ystem\\./"
+      ],
+      "extends": [
+        ":automergeBranch",
+        ":automergeMinor"
+      ]
+    }
+  ]
+}

--- a/microsoft-automerge.json
+++ b/microsoft-automerge.json
@@ -6,10 +6,6 @@
   "packageRules": [
     {
       "groupName": "microsoft",
-      "matchPackageNames": [
-        "/^[mM]icrosoft\\./",
-        "/^[sS]ystem\\./"
-      ],
       "extends": [
         ":automergeBranch",
         ":automergeMinor"

--- a/tests/BranchInfos.cs
+++ b/tests/BranchInfos.cs
@@ -1,0 +1,3 @@
+namespace renovate_config.tests;
+
+public record BranchInfos(string Title);

--- a/tests/SystemTests.cs
+++ b/tests/SystemTests.cs
@@ -186,6 +186,181 @@ public sealed class SystemTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task RenovateMicrosoftDependenciesWithAutomerge()
+    {
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+        testContext.UseRenovateFile("microsoft-automerge.json");
+
+        testContext.AddFile("project.csproj",
+          """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <ItemGroup>
+            <PackageReference Include="System.Text.Json" Version="7.0.0" />
+            <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="1.0.2" />
+            <PackageReference Include="microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.0" />
+            <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
+            <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+              <PrivateAssets>all</PrivateAssets>
+              <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            </PackageReference>
+          </ItemGroup>
+        </Project>
+        """);
+
+        await testContext.RunRenovate();
+
+        await testContext.AssertPullRequests(
+            """
+            - Title: chore(deps): update dependency system.text.json  to redacted[security]
+              Labels:
+                - security
+              PackageUpdatesInfos:
+                - Package: System.Text.Json
+                  Type: nuget
+                  Update: major
+            - Title: chore(deps): update microsoft (major)
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Microsoft.ApplicationInsights.AspNetCore
+                  Type: nuget
+                  Update: major
+                - Package: microsoft.AspNetCore.Authentication.OpenIdConnect
+                  Type: nuget
+                  Update: major
+                - Package: Microsoft.Azure.AppConfiguration.AspNetCore
+                  Type: nuget
+                  Update: major
+            """);
+
+        await testContext.AssertBranches(
+          """
+            - Title: main
+            - Title: renovate/major-microsoft
+            - Title: renovate/microsoft
+            - Title: renovate/nuget-system.text.json-vulnerability
+            """);
+    }
+
+    [Fact]
+    public async Task RenovateWorkleapDependenciesWithAutomerge()
+    {
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+        testContext.UseRenovateFile("workleap-automerge.json");
+
+        testContext.AddFile("project.csproj",
+          """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <ItemGroup>
+            <PackageReference Include="Workleap.Extensions.Mongo" Version="1.11.1" />
+            <PackageReference Include="Workleap.Extensions.Http.Authentication.ClientCredentialsGrant" Version="1.3.0" />
+            <PackageReference Include="Workleap.DomainEventPropagation.Abstractions" Version="0.2.0" />
+          </ItemGroup>
+        </Project>
+        """);
+
+        await testContext.RunRenovate();
+
+        await testContext.AssertPullRequests(
+            """
+            - Title: chore(deps): update workleap (major)
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Workleap.DomainEventPropagation.Abstractions
+                  Type: nuget
+                  Update: major
+                - Package: Workleap.Extensions.Http.Authentication.ClientCredentialsGrant
+                  Type: nuget
+                  Update: major
+            """);
+
+        await testContext.AssertBranches(
+          """
+            - Title: main
+            - Title: renovate/major-workleap
+            - Title: renovate/workleap
+            """);
+    }
+
+    [Fact]
+    public async Task RenovateDependenciesWithAllAutomerge()
+    {
+        await using var testContext = await TestContext.CreateAsync(testOutputHelper);
+        testContext.UseRenovateFile("all-automerge.json");
+
+        testContext.AddFile("project.csproj",
+          """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <ItemGroup>
+            <PackageReference Include="System.Text.Json" Version="7.0.0" />
+            <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="1.0.2" />
+            <PackageReference Include="microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.0" />
+            <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
+            <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+              <PrivateAssets>all</PrivateAssets>
+              <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            </PackageReference>
+            <PackageReference Include="Workleap.Extensions.Mongo" Version="1.11.1" />
+            <PackageReference Include="Workleap.Extensions.Http.Authentication.ClientCredentialsGrant" Version="1.3.0" />
+            <PackageReference Include="Workleap.DomainEventPropagation.Abstractions" Version="0.2.0" />
+          </ItemGroup>
+        </Project>
+        """);
+
+        await testContext.RunRenovate();
+
+        await testContext.AssertPullRequests(
+            """
+            - Title: chore(deps): update dependency system.text.json  to redacted[security]
+              Labels:
+                - security
+              PackageUpdatesInfos:
+                - Package: System.Text.Json
+                  Type: nuget
+                  Update: major
+            - Title: chore(deps): update dependency workleap.domaineventpropagation.abstractions  to redacted
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Workleap.DomainEventPropagation.Abstractions
+                  Type: nuget
+                  Update: major
+            - Title: chore(deps): update dependency workleap.extensions.http.authentication.clientcredentialsgrant  to redacted
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Workleap.Extensions.Http.Authentication.ClientCredentialsGrant
+                  Type: nuget
+                  Update: major
+            - Title: chore(deps): update microsoft (major)
+              Labels:
+                - renovate
+              PackageUpdatesInfos:
+                - Package: Microsoft.ApplicationInsights.AspNetCore
+                  Type: nuget
+                  Update: major
+                - Package: microsoft.AspNetCore.Authentication.OpenIdConnect
+                  Type: nuget
+                  Update: major
+                - Package: Microsoft.Azure.AppConfiguration.AspNetCore
+                  Type: nuget
+                  Update: major
+            """);
+
+        await testContext.AssertBranches(
+          """
+            - Title: main
+            - Title: renovate/major-microsoft
+            - Title: renovate/microsoft
+            - Title: renovate/nuget-system.text.json-vulnerability
+            - Title: renovate/workleap.domaineventpropagation.abstractions-0.x
+            - Title: renovate/workleap.domaineventpropagation.abstractions-1.x
+            - Title: renovate/workleap.extensions.http.authentication.clientcredentialsgrant-2.x
+            """);
+    }
+
+    [Fact]
     public async Task DisableGitVersionMsBuildPackage()
     {
         await using var testContext = await TestContext.CreateAsync(testOutputHelper);

--- a/workleap-automerge.json
+++ b/workleap-automerge.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+      "github>gsoft-inc/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "groupName": "workleap",
+      "matchPackageNames": [
+        "/^[wW]orkleap\\./"
+      ],
+      "extends": [
+        ":automergeBranch",
+        ":automergeMinor"
+      ]
+    }
+  ]
+}

--- a/workleap-automerge.json
+++ b/workleap-automerge.json
@@ -6,9 +6,6 @@
   "packageRules": [
     {
       "groupName": "workleap",
-      "matchPackageNames": [
-        "/^[wW]orkleap\\./"
-      ],
       "extends": [
         ":automergeBranch",
         ":automergeMinor"


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
- Added 3 new files to enable granular auto-merge possibilities for renovate on minor and patch updates
  - `microsoft-automerge.json` which handles microsoft related packages
  - `workleap-automerge.json` which handles Workleap related packages
  - `all-automerge.json` which as the name says handles all packages

## Breaking changes
None, teams can still use the `default.json` config until they're ready and confident to start auto-merging

## Additional checks
I tried the configs in ADO manually and on GitHub through the automated tests. 

Made sure that you could extend more than one config file and you would still get the extected end result.
 - For example if you reference both `microsoft-automerge.json` and `workleap-automerge.json`

Made sure that if the build validations are not green then a PR is opened instead of having the branch merged into main
